### PR TITLE
fix for acme packet sbc participants ID

### DIFF
--- a/lib/payload-parser.js
+++ b/lib/payload-parser.js
@@ -54,7 +54,14 @@ module.exports = function parseSiprecPayload(opts) {
           const participants = {} ;
           obj[`${prefix}participant`].forEach((p) => {
             const partDetails = {} ;
-            participants[p.$.participant_id] = partDetails;
+            // fix for acme packet xml participants
+            if (p.$.id) { 
+              participants[p.$.id] = partDetails;
+            }
+            else {
+              participants[p.$.participant_id] = partDetails;
+            }
+            // end of fix
             if ((`${prefix}nameID` in p) && Array.isArray(p[`${prefix}nameID`])) {
               partDetails.aor = p[`${prefix}nameID`][0].$.aor;
               if ('name' in p[`${prefix}nameID`][0] && Array.isArray(p[`${prefix}nameID`][0].name)) {


### PR DESCRIPTION
Hi,
just a little fix, because acme packet formats a differently the participant's id

```
<participant id="kaQjNo8wQtp1OJyu5UhNMA==" session="WTREQVbFS55gDsXg2DYUHA==">
```

Opensips example:
```
<participant participant_id="yLtolfgsR1W6ZDV5jJ0eeg==">
```